### PR TITLE
Add scratchpad with market research and initial plan (Vibe Kanban)

### DIFF
--- a/scratchpad/initial-plan.md
+++ b/scratchpad/initial-plan.md
@@ -1,0 +1,86 @@
+# Archetype - Initial Plan
+
+**Date:** March 15, 2026
+**Goal:** Ship consistently every day, share progress on Instagram
+
+---
+
+## The Vision
+
+**Archetype** - Production-quality, forkable base apps. Like shadcn/ui, but for entire applications.
+
+"Fork it. Own it. Ship it."
+
+---
+
+## First App: Inbox
+
+An Inbox app for iPhone and Mac that lets you quickly capture and organize links, files, and anything else. The step *before* your todo list.
+
+### Why Inbox First
+
+1. **Universal pain point.** Everyone has links, screenshots, ideas, articles scattered across Notes, Safari tabs, Messages, Slack saves, bookmarks. No clean, fast "dump it here" app exists.
+
+2. **Modern GTD gateway.** The GTD Inbox concept predates today's extreme info overload. A modern Inbox that's *just* capture + organize (not full task management) is genuinely missing.
+
+3. **Technically diverse.** Share extensions (iOS), menu bar apps (Mac), drag-and-drop, link previews, tagging, search - teaches real patterns without being overwhelming.
+
+4. **Perfect for daily shipping + Instagram.** Every day produces a tangible UI improvement to share: "Day 3: Added link preview cards", "Day 7: Share extension working on iPhone."
+
+5. **Dogfooding.** We'll actually use it, which means we'll build something real.
+
+### How It Fits the Archetype Vision
+
+The Inbox app is the first Archetype base app - the "Inbox/Capture" archetype. It serves double duty:
+- A real product people can use
+- The first proof of concept for the Archetype platform
+
+---
+
+## Parallel Track: Waitlist Page
+
+Get a waitlist landing page online early to start collecting emails and validate interest.
+
+---
+
+## Open Questions
+
+1. **Tech stack for Inbox app** - Native Swift (SwiftUI) for iPhone + Mac? Or cross-platform?
+2. **Waitlist page** - For "Archetype" (the platform) or the "Inbox app" specifically?
+3. **Name** - Going with "Archetype"? Or Bedrock / Foundry?
+
+---
+
+## Proposed Week 1
+
+### Day 1: Foundation + Waitlist
+- Set up monorepo structure
+- Create waitlist landing page
+- Deploy (Vercel) - something live immediately
+- First Instagram post: "Day 1"
+
+### Days 2-3: Inbox App - Core Shell
+- Swift/project setup for macOS + iOS
+- Basic UI shell: inbox list view, add item button
+- Local-first storage (SwiftData)
+
+### Days 4-5: Inbox App - Capture
+- iOS Share Extension
+- macOS quick-capture (global keyboard shortcut, menu bar)
+- Basic link preview fetching
+
+### Days 6-7: Inbox App - Organize
+- Tags/labels system
+- Archive/delete
+- Search
+
+---
+
+## Key Principles (from Market Research)
+
+- **App-level, not component-level** - Full applications, not just UI pieces
+- **Own the code** - Fork and customize, no dependency lock-in
+- **AI-native** - AGENTS.md files, Claude Code friendly, designed for vibe coding on top of quality foundations
+- **Educational production code** - Production-quality but deliberately readable and forkable
+- **MIT licensed** - No barriers to adoption
+- **Opinionated but ejectable** - Great defaults, easy to change

--- a/scratchpad/market-research.md
+++ b/scratchpad/market-research.md
@@ -1,0 +1,434 @@
+# Market Research Report: Open-Source "Base Apps" Platform
+## Concept: Forkable, Customizable Reference Applications with Industry-Standard UX Patterns
+
+**Date:** March 15, 2026
+**Status:** Comprehensive Analysis
+
+---
+
+## Executive Summary
+
+This report analyzes the market landscape for an open-source project that provides a collection of "base apps" (todo list, weather app, calendar, email client, etc.) with excellent foundational UX patterns, design patterns, and components -- along with development harnesses, skills/tooling, and quality standards for modification and extension.
+
+The concept occupies a genuinely underserved niche. While the ecosystem is rich with **component libraries**, **SaaS boilerplates**, and **individual open-source apps**, no project today provides a **curated collection of reference-quality, forkable applications** united by shared patterns, a common design system, and tooling that helps developers maintain quality as they customize. The closest analogues either focus on a single app category (SaaS), stop at the component level (shadcn/ui), or provide reference implementations that are too simple to be production-useful (TodoMVC, RealWorld).
+
+---
+
+## 1. Competitive Landscape
+
+### 1.1 Component Libraries & Design Systems (Component-Level, Not App-Level)
+
+These projects provide the building blocks but NOT complete applications:
+
+| Project | Stars | What It Does | Gap vs. This Concept |
+|---------|-------|-------------|---------------------|
+| [shadcn/ui](https://ui.shadcn.com/) | 105k+ | Copy-paste React components built on Radix UI + Tailwind | Components only, not full apps. No app-level patterns (routing, state, data flow). |
+| [Once UI](https://once-ui.com/) | Growing | Design system for indie creators with copy-paste layouts and pages | Closer to full apps but narrowly focused on landing pages and marketing sites, not productivity apps. |
+| [Carbon Design System](https://carbondesignsystem.com/) (IBM) | Mature | Enterprise design system with components + guidelines | Components and guidelines only; no reference applications. |
+| [PatternFly](https://www.patternfly.org/) (Red Hat) | Mature | Enterprise design system for building at scale | Same -- components, not apps. |
+| [Cult UI](https://www.cult-ui.com/) | Growing | shadcn components, blocks, and templates | Templates are page-level, not full app architectures. |
+
+**Key takeaway:** The component library space is crowded and well-served. shadcn/ui's explosive growth (0 to 105k stars in ~3 years) proves massive developer appetite for "own the code" patterns. But nobody has taken this model to the **full application level**.
+
+### 1.2 SaaS Boilerplates & Starter Kits (App-Level, But SaaS-Only)
+
+These projects provide full applications, but they are overwhelmingly focused on a single archetype: the SaaS business app.
+
+| Project | Stars | What It Does | Gap vs. This Concept |
+|---------|-------|-------------|---------------------|
+| [Wasp Open SaaS](https://github.com/wasp-lang/open-saas) | 10k+ | Free, full-featured SaaS boilerplate (React, Node.js, Prisma) with auth, payments, landing page, AI-ready | SaaS-only. Great quality but only one "app type." |
+| [create-t3-app](https://github.com/t3-oss/create-t3-app) | 21.9k | CLI to scaffold typesafe Next.js apps | Scaffolding tool, not a reference app. Generates blank projects. |
+| [SaaS Boilerplate (ixartz)](https://github.com/ixartz/SaaS-Boilerplate) | Popular | Next.js + Tailwind + shadcn SaaS starter | SaaS-only, landing page + dashboard archetype. |
+| [SaaS Boilerplate (apptension)](https://github.com/apptension/saas-boilerplate) | Popular | React + Django + AWS SaaS foundation | SaaS-only, enterprise-oriented. |
+| [Hilla](https://vaadin.com/hilla) (Vaadin) | Niche | Full-stack React + Spring Boot framework | Framework, not reference apps. Java ecosystem. |
+
+**Aggregator sites:** [BoilerplateList.com](https://boilerplatelist.com/), [OpenSourceBoilerplates.com](https://opensourceboilerplates.com/), and the [awesome-opensource-boilerplates](https://github.com/EinGuterWaran/awesome-opensource-boilerplates) GitHub repo catalog dozens of boilerplates -- virtually all are SaaS starters, not diverse app archetypes.
+
+**Key takeaway:** The boilerplate market is heavily concentrated on "SaaS with auth + payments + landing page." Nobody is providing reference implementations for **calendar apps, email clients, weather dashboards, note-taking tools**, etc.
+
+### 1.3 Reference Implementation Projects (App-Level, But Too Simple)
+
+| Project | Stars | What It Does | Gap vs. This Concept |
+|---------|-------|-------------|---------------------|
+| [TodoMVC](https://todomvc.com/) | Legacy | Same todo app in every JS framework | Extremely simple; meant for framework comparison, not as a production foundation. No real UX patterns. |
+| [RealWorld (Conduit)](https://github.com/gothinkster/realworld) | 7.5k | Medium.com clone in 100+ framework combinations | One app type (blog/social). Quality varies wildly across implementations. Focused on framework comparison, not production UX. |
+
+**Key takeaway:** TodoMVC and RealWorld validated the concept of "same app, multiple implementations" but are specifically designed for **framework comparison**, not as **production-quality starting points**. Their apps are deliberately simple. This concept would be the **production-grade evolution** of that idea.
+
+### 1.4 Individual Open-Source Apps (Production-Quality, But Siloed)
+
+These are real, production-grade open-source applications, but they exist in isolation with no shared patterns or development harnesses:
+
+**Email Clients:**
+- [Proton WebClients](https://github.com/ProtonMail/WebClients) -- Monorepo with 14+ apps and 30+ shared packages. Excellent architecture but massive complexity (encryption, key transparency, etc.). GPL-licensed. Very hard to fork for a simple email client.
+- [Mail Zero](https://github.com/Mail-0/Zero) -- Open-source AI email app focused on privacy. Modern but specialized.
+- [Roundcube](https://roundcube.net/) -- Mature PHP webmail client. Dated architecture.
+
+**Calendar Apps:**
+- [Cal.com](https://github.com/calcom/cal.com) -- 40.4k stars, 12.1k forks. Scheduling infrastructure, not a general calendar. AGPL license.
+- [FullCalendar](https://fullcalendar.io/) -- Calendar component (widget), not a full app.
+
+**Todo / Task Management:**
+- [Vikunja](https://vikunja.io/) -- Self-hosted task manager with lists, Kanban, subtasks. Full-featured but its own opinionated thing.
+- [Super Productivity](https://github.com/super-productivity/super-productivity) -- Advanced todo with timeboxing and integrations.
+
+**Key takeaway:** Excellent open-source alternatives exist for individual app categories, but they are all **independent projects with their own stacks, patterns, and complexity levels**. A developer who wants to learn from Gmail's patterns cannot realistically fork Proton Mail's 14-app monorepo with encryption layers. There is no "simplified, educational, forkable" version of these apps that shares common patterns.
+
+### 1.5 AI App Builders & Vibe Coding Tools (Generate, Don't Teach)
+
+| Tool | Type | Gap vs. This Concept |
+|------|------|---------------------|
+| [v0.dev](https://v0.dev) (Vercel) | AI UI generator | Generates components/pages, not full app architectures. No persistent patterns. |
+| [Bolt.new](https://bolt.new) (StackBlitz) | AI full-stack generator | Generates throwaway apps from prompts. No curated quality or UX standards. |
+| [Lovable](https://lovable.dev) | AI app builder | Same: generates code, doesn't teach patterns. |
+| [Dyad](https://github.com/dyad-sh/dyad) | Local open-source AI builder | Privacy-focused alternative but same "generate from prompt" paradigm. |
+
+**Key takeaway:** AI tools generate code fast but produce apps with significant quality problems. A December 2025 CodeRabbit analysis found AI-generated code has **2.74x more security vulnerabilities** and **75% more misconfigurations** than human-written code. The vibe coding trend has created massive demand for **guardrails and quality standards** -- exactly what this concept provides.
+
+### 1.6 Low-Code / Internal Tool Builders (Different Audience)
+
+| Project | Stars | What It Does | Gap vs. This Concept |
+|---------|-------|-------------|---------------------|
+| [Refine](https://github.com/refinedev/refine) | Growing | React meta-framework for CRUD apps, admin panels, dashboards | Focused on CRUD/admin use cases. Headless but opinionated about data patterns. |
+| [Appsmith](https://www.appsmith.com/) | Popular | Low-code internal tool builder | Drag-and-drop; different audience than developers who want to own code. |
+| [ToolJet](https://www.tooljet.com/) | Popular | Open-source internal tool builder | Same: low-code, internal tools. |
+| [Budibase](https://budibase.com/) | Popular | Auto-generate internal tools from data | Same category. |
+
+**Key takeaway:** These serve a different audience (teams building internal tools quickly) and a different paradigm (low-code/no-code). The proposed concept targets developers who want to **own and understand the code** while starting from a quality foundation.
+
+### 1.7 Full-Stack Frameworks with App Templates
+
+| Project | Stars | What It Does | Gap vs. This Concept |
+|---------|-------|-------------|---------------------|
+| [Wasp](https://wasp.sh/) | 26k | "Laravel for JS" -- batteries-included framework | Framework-first; provides one SaaS template (Open SaaS). Not a collection of diverse apps. |
+| [Redwood.js](https://redwoodjs.com/) | Established | Full-stack JS framework | Framework, not reference apps. |
+
+---
+
+## 2. Market Gaps
+
+Based on the research, the following critical gaps exist in the current landscape:
+
+### Gap 1: No "shadcn/ui for Full Apps"
+shadcn/ui proved there is massive demand for ownable, copy-paste code. But it stops at the component level. There is nothing that provides **full application architectures** with the same "fork it, own it, customize it" philosophy.
+
+### Gap 2: No Diverse App Archetype Collection
+Every boilerplate is a SaaS starter. Nobody is providing reference-quality implementations of **diverse app types** -- email, calendar, weather, notes, chat -- that share common patterns. A developer building a calendar app has no quality starting point that is simpler than forking Cal.com's 40k-star enterprise scheduling platform.
+
+### Gap 3: No Quality Bridge Between AI-Generated and Production Code
+The vibe coding revolution has produced a flood of AI-generated apps that are "almost right, but not quite" (the #1 developer frustration at 66% in the 2025 Stack Overflow survey). There is no project that provides **curated, human-reviewed, production-quality app patterns** that AI tools can use as reference or that developers can use to validate AI output against.
+
+### Gap 4: No Shared Development Harness Across App Types
+Individual open-source apps each have their own testing, linting, CI/CD, and contribution patterns. There is no project providing a **unified development harness** that enforces quality standards across a collection of diverse applications.
+
+### Gap 5: No "Educational Production Code"
+Proton Mail's WebClients monorepo is real production code but impenetrably complex for learning. TodoMVC is educational but toy-level. Nothing exists in the middle: **production-quality code that is deliberately designed to be readable, forkable, and educational**.
+
+---
+
+## 3. Target Audience
+
+### Primary Audiences
+
+**1. Indie Hackers & Solo Developers (Largest Segment)**
+- **Size:** Millions globally; the indie hacker movement continues to accelerate in 2025-2026.
+- **Pain points:** Need to ship fast but lack design/UX expertise. Spend too much time on boilerplate. Can't afford to hire designers. Current AI tools generate code that looks good but has quality problems.
+- **What they want:** "Give me a professional-looking, well-architected starting point for my app idea that I can customize without understanding every line from day one."
+- **Quote from research:** "Building is the easy part. The main struggles for solo developers aren't technical anymore" -- but they still waste weeks on foundational UI/UX decisions.
+
+**2. Developers Using AI Coding Tools (Rapidly Growing)**
+- **Size:** 84% of developers are using or planning to use AI tools (2025 Stack Overflow survey).
+- **Pain points:** AI generates code that is "almost right" (66% frustration). Debugging AI code is more time-consuming (45%). Trust in AI output is low (only 29% trust accuracy). Need reference implementations to validate against.
+- **What they want:** "Give me a known-good reference app that I can point my AI assistant at, so it generates code that follows established patterns instead of hallucinating new ones."
+
+**3. Small Teams & Startups (High Value)**
+- **Size:** Tens of thousands of new startups annually.
+- **Pain points:** Need to move fast but maintain code quality. Can't afford to build everything from scratch. Don't want vendor lock-in from paid templates.
+- **What they want:** "Give me a head start on my app with patterns I can trust, that my whole team can understand, and that I can extend without hitting walls."
+
+**4. Developers Learning Best Practices (Educational)**
+- **Size:** Large -- millions of intermediate developers globally.
+- **Pain points:** Tutorial apps are too simple. Real-world apps are too complex. No middle ground for learning production patterns.
+- **What they want:** "Show me how a professional calendar/email/todo app is actually built -- the routing, state management, data patterns, error handling -- in code I can actually read and understand."
+
+### Secondary Audiences
+
+**5. Companies Building Custom Internal Tools** -- Want professional-looking apps without enterprise tool builder lock-in.
+
+**6. Educators & Bootcamps** -- Need production-quality reference implementations for teaching.
+
+**7. Design System Teams** -- Want to see how their components work in real app contexts, not just Storybook.
+
+---
+
+## 4. Differentiation Opportunities
+
+### 4.1 Core Differentiator: App-Level, Not Component-Level
+
+The single most powerful differentiator: **this would be the first project to apply the shadcn/ui philosophy (own the code, customize freely) at the full application level, across multiple app archetypes.**
+
+shadcn/ui: "Here are components you can copy and own."
+This project: "Here are entire applications you can fork and own."
+
+### 4.2 Diversity of App Types
+
+While every competitor focuses on ONE app type (usually SaaS), this project provides MANY:
+- Email client (industry-standard inbox patterns: threading, labels, search, compose)
+- Calendar (event CRUD, views, recurring events, drag-to-create)
+- Todo / task manager (lists, kanban, priorities, due dates)
+- Weather dashboard (data visualization, geolocation, API integration patterns)
+- Notes / document editor (rich text, markdown, organization, search)
+- Chat / messaging (real-time, threads, presence, notifications)
+
+Each app teaches different architectural patterns. Together they form a comprehensive education in production web development.
+
+### 4.3 AI-Native Design: The "Quality Anchor" for Vibe Coding
+
+Position the project as the **antidote to low-quality AI-generated code.** Every base app includes:
+- An `AGENTS.md` or equivalent file that AI tools can consume (following Wasp Open SaaS's proven pattern)
+- Claude Code / Cursor / Copilot-friendly documentation
+- Clear architectural "guardrails" that help AI assistants generate code that follows the established patterns
+
+This creates a powerful narrative: "Don't vibe-code from scratch. Vibe-code on top of a quality foundation."
+
+### 4.4 Unified Development Harness
+
+No other project provides a **cross-app development harness** that includes:
+- Shared linting and formatting rules
+- Common testing patterns and helpers
+- Consistent CI/CD templates
+- Shared component library (the "design system" layer)
+- Quality gates that run on every PR
+- Architecture decision records (ADRs) explaining pattern choices
+
+### 4.5 "Opinionated but Ejectable"
+
+Learn from shadcn/ui's positioning: don't be a framework, be a starting point. Each base app should be:
+- Fully functional out of the box
+- Completely forkable and independent
+- Well-documented with "why" explanations, not just "how"
+- Free of proprietary dependencies or vendor lock-in
+- Licensed permissively (MIT or similar)
+
+---
+
+## 5. Naming & Positioning
+
+### 5.1 Positioning Strategy
+
+Based on analysis of how successful open-source projects position themselves:
+
+**shadcn/ui succeeded because it positioned as:**
+- "Not a component library" (anti-positioning)
+- "Copy and paste. Own the code." (ownership narrative)
+- Foundation for YOUR design system (empowerment)
+
+**Cal.com succeeded because it positioned as:**
+- "Scheduling infrastructure for absolutely everyone" (democratization)
+- Open-source Calendly alternative (familiar anchor)
+
+**Wasp succeeded because it positioned as:**
+- "Laravel for JS" (familiar metaphor)
+- "Batteries-included" (completeness)
+- "Full-stack framework for the AI era" (timing)
+
+### 5.2 Recommended Positioning Angles
+
+**Option A: "The App Forge"**
+*"Production-quality starter apps you can fork, customize, and ship. Like shadcn/ui, but for entire applications."*
+
+Rationale: Directly leverages shadcn/ui's massive mindshare. Immediately communicates the "own the code" value proposition. "Forge" implies both creation and strengthening.
+
+**Option B: "The App Patterns"**
+*"Industry-standard app patterns you can actually use. Fork a professional email client, calendar, or todo app -- then make it yours."*
+
+Rationale: Emphasizes the educational/pattern aspect. Appeals to developers who want to learn by doing.
+
+**Option C: "App Foundations"**
+*"Don't start from scratch. Don't fight a framework. Start from a foundation."*
+
+Rationale: Positions between "blank slate" (too much work) and "framework" (too constraining). The word "foundation" implies solidity and buildability.
+
+### 5.3 Naming Recommendations
+
+Based on research into open-source naming best practices:
+
+| Name | Pros | Cons |
+|------|------|------|
+| **Basecamp** | Perfect metaphor (base camp = starting point for a journey) | Taken by 37signals |
+| **Foundry** | Implies forging/creating; technical feel | Slightly generic |
+| **Scaffold** | Directly describes the concept | Too associated with Rails scaffolding; implies temporary |
+| **Archetype** | Literally means "original pattern" | Might sound academic |
+| **Blueprint** | Implies plans/patterns you follow | Common word; hard to own in search |
+| **Primer** | Educational connotation; "first coat of paint" | GitHub has a design system called Primer |
+| **Basekit** | "Base" + "kit" -- direct and descriptive | Might sound like a WordPress theme |
+| **Stockwork** | Implies foundational framework (architectural term) | Obscure |
+| **Launchpad** | Implies starting point for launch | Overused in tech |
+| **Bedrock** | Solid foundation metaphor; single distinctive word | Strong; searchable |
+| **Cornerstone** | Foundation metaphor | Slightly long |
+
+**Top recommendations:**
+1. **Bedrock** -- Strong metaphor (the solid foundation everything is built on), single word, distinctive, good for SEO, not taken in the JS/React ecosystem.
+2. **Foundry** -- Implies crafting and forging, technical yet accessible, short and memorable.
+3. **Archetype** -- Literally means "the original pattern from which copies are made" -- which is exactly what this project does.
+
+### 5.4 Tagline Recommendations
+
+- "Fork it. Own it. Ship it." (Action-oriented, echoes shadcn)
+- "Real apps. Real patterns. Your code." (Emphasizes production quality)
+- "The starting point for every app you'll ever build." (Ambitious, memorable)
+- "Production-ready apps you can actually understand." (Addresses the Proton Mail complexity problem)
+- "Base apps for builders." (Simple, direct)
+
+---
+
+## 6. Strategic Recommendations
+
+### 6.1 Start with 3-4 High-Impact App Types
+
+Don't try to launch all app types at once. Prioritize based on developer demand and pattern diversity:
+
+1. **Todo / Task Manager** -- Universal demand, teaches state management, CRUD, drag-and-drop, keyboard shortcuts.
+2. **Email Client** -- High aspiration ("fork Gmail"), teaches threading, search, compose, rich text, keyboard-heavy UX.
+3. **Calendar** -- Teaches complex date/time handling, drag interactions, recurring events, view switching.
+4. **Weather Dashboard** -- Teaches API integration, data visualization, geolocation, caching patterns.
+
+### 6.2 Adopt the shadcn/ui Distribution Model
+
+Do NOT distribute as an npm package. Instead:
+- Provide a CLI that copies app source code into the developer's project
+- Or simply provide a "Use this template" / "Fork" button on GitHub
+- The code becomes THEIRS immediately -- no dependency to manage
+
+### 6.3 Be AI-Native from Day One
+
+Given that 41% of all code written globally is now AI-generated:
+- Include `AGENTS.md` files in every app describing the architecture for AI tools
+- Provide Claude Code skills/plugins for modifying each base app
+- Write documentation in a format that LLMs can consume effectively
+- Test each app with popular AI coding tools to ensure they work well as starting points
+
+### 6.4 Build Community Through Pattern Documentation
+
+Each base app should include:
+- **Architecture Decision Records (ADRs)** explaining WHY patterns were chosen
+- **UX Pattern Documentation** explaining the interaction design decisions
+- **"How Gmail/Google Calendar/Todoist does it"** reference documentation
+- **Progressive complexity guides** showing how to evolve the base app
+
+### 6.5 License Permissively
+
+Use MIT license. Cal.com's AGPL and Proton's GPL create friction for commercial use. MIT removes all barriers to adoption and signals "this is truly for you to use however you want."
+
+### 6.6 Timing is Ideal
+
+The convergence of several trends makes 2026 the perfect moment:
+- **Vibe coding backlash** is creating demand for quality foundations (the "Vibe Coding Kills Open Source" paper, January 2026)
+- **AI coding trust deficit** (only 29% of developers trust AI output accuracy)
+- **shadcn/ui has educated the market** on "own the code" philosophy
+- **Solo developer / indie hacker boom** is accelerating
+- **Component libraries are mature** but the "full app" layer above them is empty
+
+---
+
+## 7. Risk Assessment
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Maintenance burden of multiple apps | High | Start with 3-4; use shared monorepo architecture (learn from Proton's approach) |
+| Apps become outdated as frameworks evolve | Medium | Focus on patterns over frameworks; abstract framework-specific code |
+| "Too opinionated" criticism | Medium | Position as "starting point, not framework"; make ejection easy |
+| Competition from AI app generators improving | Medium | Position as complementary: "the quality foundation AI builds on top of" |
+| Difficulty attracting contributors to multiple apps | Medium | Clear contribution guides; each app as a self-contained contribution opportunity |
+| Confusion about what the project IS | High | Strong positioning and clear landing page; demo each app prominently |
+
+---
+
+## 8. Conclusion
+
+The proposed concept fills a genuine, significant gap in the developer tooling ecosystem. The market has mature component libraries (shadcn/ui), mature single-app open-source alternatives (Cal.com, Proton), and mature SaaS boilerplates (Open SaaS) -- but nothing that provides a **curated collection of diverse, production-quality, forkable applications** with shared patterns and a development harness.
+
+The timing is ideal: developers are drowning in AI-generated code of questionable quality and are hungry for quality foundations they can trust and customize. The shadcn/ui model has proven that "own the code" distribution resonates massively with developers.
+
+The primary execution challenge will be maintaining quality across multiple app types while keeping each app simple enough to be genuinely forkable. The Proton WebClients monorepo is a cautionary example of shared-code architecture done at enterprise scale that becomes too complex for others to use. This project must stay on the "forkable" side of that complexity line.
+
+**Bottom line:** This concept has strong product-market fit potential if executed with discipline around simplicity, quality, and the "own the code" philosophy that has proven successful in adjacent projects.
+
+---
+
+## Sources
+
+### Component Libraries & Design Systems
+- [shadcn/ui](https://ui.shadcn.com/)
+- [Once UI](https://once-ui.com/)
+- [Carbon Design System](https://carbondesignsystem.com/)
+- [PatternFly](https://www.patternfly.org/)
+- [awesome-shadcn-ui](https://github.com/birobirobiro/awesome-shadcn-ui)
+- [Shadcn Templates](https://shadcntemplates.com)
+- [Cult UI](https://www.cult-ui.com/)
+- [shadcn/ui Adoption Guide (LogRocket)](https://blog.logrocket.com/shadcn-ui-adoption-guide/)
+- [Rise of shadcn/ui (SaaSIndie)](https://saasindie.com/blog/shadcn-ui-trends-and-future)
+- [Why Developers Switch to shadcn/ui (OpenReplay)](https://blog.openreplay.com/developers-switching-shadcn-ui-react/)
+
+### Boilerplates & Starter Kits
+- [Wasp Open SaaS](https://github.com/wasp-lang/open-saas)
+- [create-t3-app](https://github.com/t3-oss/create-t3-app)
+- [SaaS Boilerplate (ixartz)](https://github.com/ixartz/SaaS-Boilerplate)
+- [SaaS Boilerplate (apptension)](https://github.com/apptension/saas-boilerplate)
+- [BoilerplateList.com](https://boilerplatelist.com/)
+- [OpenSourceBoilerplates.com](https://opensourceboilerplates.com/)
+- [awesome-opensource-boilerplates](https://github.com/EinGuterWaran/awesome-opensource-boilerplates)
+- [2026 Boilerplate](https://github.com/bishopZ/2026-Boilerplate)
+- [From 0 to 10K Stars: Open SaaS (DEV)](https://dev.to/wasp/from-0-to-10k-how-open-saas-became-the-free-boilerplate-devs-love-45hb)
+- [Next.js Enterprise Boilerplate](https://nextjstemplates.com/blog/nextjs-boilerplates)
+
+### Reference Implementation Projects
+- [TodoMVC](https://todomvc.com/)
+- [RealWorld / Conduit](https://github.com/gothinkster/realworld)
+- [TodoMVC App Spec](https://github.com/tastejs/todomvc/blob/master/app-spec.md)
+
+### Individual Open-Source Apps
+- [Proton WebClients](https://github.com/ProtonMail/WebClients)
+- [Mail Zero](https://github.com/Mail-0/Zero)
+- [Cal.com](https://github.com/calcom/cal.com)
+- [FullCalendar](https://fullcalendar.io/)
+- [Vikunja](https://vikunja.io/)
+- [Super Productivity](https://github.com/super-productivity/super-productivity)
+- [Proton WebClients Architecture (DeepWiki)](https://deepwiki.com/ProtonMail/WebClients)
+
+### Full-Stack Frameworks
+- [Wasp](https://wasp.sh/)
+- [Hilla (Vaadin)](https://vaadin.com/hilla)
+- [Scaffold-ETH 2](https://scaffoldeth.io/)
+- [Refine](https://github.com/refinedev/refine)
+- [Wasp TechCrunch Coverage](https://techcrunch.com/2025/04/17/wasps-platform-is-the-glue-that-holds-web-apps-together/)
+
+### AI App Builders & Vibe Coding
+- [v0.dev (Vercel)](https://v0.dev)
+- [Bolt.new (StackBlitz)](https://bolt.new)
+- [Dyad](https://github.com/dyad-sh/dyad)
+- [Vibe Coding (Wikipedia)](https://en.wikipedia.org/wiki/Vibe_coding)
+- [State of Vibecoding Feb 2026](https://www.kristindarrow.com/insights/the-state-of-vibecoding-in-feb-2026)
+- [Vibe Coding Statistics 2026](https://www.secondtalent.com/resources/vibe-coding-statistics/)
+
+### Low-Code / Internal Tool Builders
+- [Appsmith](https://www.appsmith.com/)
+- [ToolJet](https://blog.tooljet.com/appsmith-vs-budibase-vs-tooljet/)
+- [Budibase](https://budibase.com/)
+
+### Developer Surveys & Pain Points
+- [2025 Stack Overflow Developer Survey](https://survey.stackoverflow.co/2025)
+- [Stack Overflow Blog: Developer Frustrations](https://stackoverflow.blog/2025/12/29/developers-remain-willing-but-reluctant-to-use-ai-the-2025-developer-survey-results-are-here/)
+- [Harness Report: AI Coding vs DevOps Maturity](https://www.prnewswire.com/news-releases/harness-report-reveals-ai-coding-accelerates-development-devops-maturity-in-2026-isnt-keeping-pace-302710937.html)
+- [Code Boilerplates and Starting From Scratch (Medium)](https://medium.com/@MrBenJ/code-boilerplates-and-the-hidden-benefits-of-starting-from-scratch-58778226436c)
+- [Boilerplate vs Building from Scratch 2025](https://pratikmistry.medium.com/boilerplate-vs-building-from-scratch-what-to-pick-in-2025-09d99116b74d)
+
+### Naming & Branding
+- [How to Choose a Brand Name for Open Source (Opensource.com)](https://opensource.com/business/16/2/how-choose-brand-name-open-source-project)
+- [Choosing Project Names: 4 Key Considerations](https://opensource.com/article/18/2/choosing-project-names-four-key-considerations)
+- [Project Naming in Open Source 2025 (Namesmith)](https://namesmith.ai/blog/project-naming-open-source-community-engagement-creative-naming)
+
+### Indie Developer Ecosystem
+- [Indie Hacker Tools 2025](https://www.builtthisweek.com/blog/indie-hacker-tools-2025)
+- [I Built 20+ Apps: The Platform I Wish Existed](https://medium.com/@eibrahim/i-built-20-apps-in-a-year-heres-the-platform-i-wish-existed-84b9b9bca195)
+- [Indie Dev Toolkit (GitHub)](https://github.com/thedaviddias/indie-dev-toolkit)


### PR DESCRIPTION
## Summary

- Added a `scratchpad/` directory to consolidate planning and research documents
- Copied the comprehensive market research report from the init workspace
- Created an initial plan document capturing the project direction

## What changed

**`scratchpad/market-research.md`** - Full market research report analyzing the landscape for an open-source "base apps" platform. Covers competitive analysis across component libraries, SaaS boilerplates, reference implementations, individual open-source apps, AI app builders, and low-code tools. Identifies 5 key market gaps and provides naming/positioning recommendations.

**`scratchpad/initial-plan.md`** - Initial project plan for Archetype, establishing:
- The Inbox app as the first base app to build (a fast capture + organize tool for iPhone and Mac)
- Rationale for why Inbox is the right starting point
- A proposed Week 1 breakdown focused on daily shipping
- Key principles carried forward from the market research
- Open questions on tech stack, waitlist scope, and naming

## Why

The project needed a central place to collect planning artifacts before moving into implementation. The market research was sitting in a separate workspace (`a540-init`) and the initial plan discussion needed to be captured in durable form. This consolidation sets the stage for the next phase: answering the open questions and starting to build.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)